### PR TITLE
Changes in Controller & Model files (messages & default state functionality)

### DIFF
--- a/administrator/components/com_workflow/Model/StateModel.php
+++ b/administrator/components/com_workflow/Model/StateModel.php
@@ -265,7 +265,7 @@ class StateModel extends AdminModel
 
 		if ($table->load(array('id' => $pk)))
 		{
-			if ($table->published == 0)
+			if ($table->published !== 1)
 			{
 				$this->setError(\JText::_("COM_WORKFLOW_ITEM_MUST_PUBLISHED"));
 

--- a/administrator/components/com_workflow/Model/StateModel.php
+++ b/administrator/components/com_workflow/Model/StateModel.php
@@ -265,7 +265,7 @@ class StateModel extends AdminModel
 
 		if ($table->load(array('id' => $pk)))
 		{
-			if ($table->published !== 1)
+			if ($table->published == 0)
 			{
 				$this->setError(\JText::_("COM_WORKFLOW_ITEM_MUST_PUBLISHED"));
 

--- a/administrator/components/com_workflow/Model/StateModel.php
+++ b/administrator/components/com_workflow/Model/StateModel.php
@@ -265,7 +265,7 @@ class StateModel extends AdminModel
 
 		if ($table->load(array('id' => $pk)))
 		{
-			if ($table->published == 0)
+			if ($table->published != 1)
 			{
 				$this->setError(\JText::_("COM_WORKFLOW_ITEM_MUST_PUBLISHED"));
 

--- a/administrator/components/com_workflow/Model/StateModel.php
+++ b/administrator/components/com_workflow/Model/StateModel.php
@@ -265,7 +265,7 @@ class StateModel extends AdminModel
 
 		if ($table->load(array('id' => $pk)))
 		{
-			if ($table->published !== 1)
+			if ($table->published == 0)
 			{
 				$this->setError(\JText::_("COM_WORKFLOW_ITEM_MUST_PUBLISHED"));
 
@@ -320,7 +320,8 @@ class StateModel extends AdminModel
 				if ($table->load(array('id' => $pk)) && $table->default)
 				{
 					// Prune items that you can't change.
-					$app->enqueueMessage(\JText::_('COM_WORKFLOW_ITEM_MUST_PUBLISHED'), 'error');
+					$app->enqueueMessage(\JText::_('COM_WORKFLOW_MSG_DELETE_DEFAULT'), 'error');
+
 					unset($pks[$i]);
 				}
 			}

--- a/administrator/components/com_workflow/Model/StateModel.php
+++ b/administrator/components/com_workflow/Model/StateModel.php
@@ -265,7 +265,7 @@ class StateModel extends AdminModel
 
 		if ($table->load(array('id' => $pk)))
 		{
-			if ($table->published != 1)
+			if (!$table->published)
 			{
 				$this->setError(\JText::_("COM_WORKFLOW_ITEM_MUST_PUBLISHED"));
 

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -244,12 +244,12 @@ class AdminController extends BaseController
 				{
 					$ntext = $this->text_prefix . '_N_ITEMS_ARCHIVED';
 				}
-				/*else
+
 				{
 					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
-				}*/
+				}
 
-				if ($ntext !== null)
+				if (count($cid) != 0)
 				{
 					$this->setMessage(\JText::plural($ntext, count($cid)));
 				}

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -244,10 +244,10 @@ class AdminController extends BaseController
 				{
 					$ntext = $this->text_prefix . '_N_ITEMS_ARCHIVED';
 				}
-				else
+				/*else
 				{
 					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
-				}
+				}*/
 
 				if ($ntext !== null)
 				{

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -249,7 +249,7 @@ class AdminController extends BaseController
 					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
 				}
 
-				if (count($cid) != 0)
+				if (count($cid))
 				{
 					$this->setMessage(\JText::plural($ntext, count($cid)));
 				}

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -245,7 +245,7 @@ class AdminController extends BaseController
 					$ntext = $this->text_prefix . '_N_ITEMS_ARCHIVED';
 				}
 
-				{
+				else {
 					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
 				}
 

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -135,6 +135,21 @@ class PlgContentJoomla extends CMSPlugin
 		}
 	}
 
+    /**
+     * Don't allow categories to be deleted if they contain items or subcategories with items
+     *
+     * @param   object  $data     The data relating to the content that was deleted.
+     *
+     * @return  boolean
+     *
+     * @since   1.6
+     */
+    public function onContentBeforeDeleteCategories($data)
+    {
+        return $this->_canDeleteCategories($data);
+
+    }
+
 	/**
 	 * Checks if a given category can be deleted
 	 *
@@ -203,6 +218,7 @@ class PlgContentJoomla extends CMSPlugin
 							. Text::plural('COM_CATEGORIES_HAS_SUBCATEGORY_ITEMS', $count);
 						Factory::getApplication()->enqueueMessage($msg, 'error');
 						$result = false;
+
 					}
 				}
 			}

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -240,8 +240,12 @@ class PlgContentJoomla extends CMSPlugin
 		// Now check to see if this is a known core extension
 		if (isset($tableInfo[$extension]))
 		{
+
+            // Get table name for known core extensions
+            $table = $tableInfo[$extension]['table_name'];
+
 			// See if this category has any content items
-			$count = $this->_countItemsFromState($extension, $pk, $tableInfo[$extension]);
+			$count = $this->_countItemsFromState($extension, $pk, $table);
 
 			// Return false if db error
 			if ($count === false)
@@ -370,12 +374,13 @@ class PlgContentJoomla extends CMSPlugin
 	{
 		$query = $this->db->getQuery(true);
 
-		$query	->select('COUNT(' . $this->db->quoteName('wa.item_id') . ')')
-				->from($query->quoteName('#__workflow_associations', 'wa'))
-				->from($this->db->quoteName($table, 'b'))
-				->where($this->db->quoteName('wa.item_id') . ' = ' . $query->quoteName('b.id'))
-				->where($this->db->quoteName('wa.state_id') . ' = ' . (int) $state_id)
-				->where($this->db->quoteName('wa.extension') . ' = ' . $this->db->quote($extension));
+        $query	->select('COUNT(' . $this->db->quoteName('wa.item_id') . ')')
+            ->from($query->quoteName('#__workflow_associations', 'wa'))
+            ->from($this->db->quoteName($table, 'b'))
+            ->where($this->db->quoteName('wa.item_id') . ' = ' . $query->quoteName('b.id'))
+            ->where($this->db->quoteName('wa.state_id') . ' = ' . (int) $state_id)
+            ->where($this->db->quoteName('wa.extension') . ' = ' . $this->db->quote($extension));
+
 
 		try
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
**Issue1:** 
While managing states and trying to delete a state that is set to default the user received an error message saying "Item must be published to set default state." (COM_WORKFLOW_ITEM_MUST_PUBLISHED) whereas it should be "You are trying to delete the default item." (COM_WORKFLOW_MSG_DELETE_DEFAULT).
=> StateModel.php JText

Furthermore the user received a confirmation message even if 0 items were deleted. Changed condition of last if statement in function publish(). Now a confirmation message is only sent if the number of deleted items is greater than 0.
=> AdminController.php

**Issue2:**
It was not possible to change the default status of the states via the star icon. Fixed this issue.
=> StateModel.php

### Testing Instructions
-> Go to Content / Workflows / Workflows / Manage
- Try to delete a default state and take a look at the (error) message concerning the process and the number of deleted items.
- Try to change the default status of a state via the star icon (must be published).

### Expected result
Appropriate (error) messages and functionality of the default option (star icon).


### Actual result
Works as expected.

### Documentation Changes Required
None.
