### PR TITLE
Added the workflow to the main menu because due to some changes in th…

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -33,8 +33,14 @@
 				type="component"
 				element="com_content"
 				link="index.php?option=com_content&amp;view=featured"
-				class="class:featured"
-		/>
+				class="class:featured" >
+		</menuitem>
+		<menuitem
+			title="MOD_MENU_COM_CONTENT_WORKFLOW"
+			type="component"
+			element="com_workflow"
+			link="index.php?option=com_workflow&amp;extension=com_content">
+		</menuitem>
 		<menuitem
 				type="separator"
 		/>

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -219,8 +219,14 @@
 			title="MOD_MENU_COM_CONTENT_FEATURED"
 			type="component"
 			element="com_content"
-			link="index.php?option=com_content&amp;view=featured"
-		/>
+			link="index.php?option=com_content&amp;view=featured">
+		</menuitem>
+		<menuitem
+			title="MOD_MENU_COM_CONTENT_WORKFLOW"
+			type="component"
+			element="com_workflow"
+			link="index.php?option=com_workflow&amp;extension=com_content">
+		</menuitem>
 		<menuitem
 			type="separator"
 		/>


### PR DESCRIPTION
### Summary of Changes
Due to changes in the backend navbar, and removal of the sidebar in com_content, the workflow component is now added to the content submenu. 

Note: until now the workflow was added to the submenu of com_content only when the param "enabled" was set, as com_fields. Now it is fixed in the submenu.
