### PR TITLE
Fix redirect after warning

### DIFF
--- a/administrator/components/com_workflow/src/Controller/WorkflowsController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowsController.php
@@ -119,8 +119,8 @@ class WorkflowsController extends AdminController
 			$this->setMessage(Text::_('COM_WORKFLOW_DISABLE_DEFAULT'), 'warning');
 			$this->setRedirect(
 				Route::_(
-				'index.php?option=' . $this->option . '&view=' . $this->view_list
-				. '&extension=' . $this->extension . ($this->section ? '.' . $this->section : ''), false
+					'index.php?option=' . $this->option . '&view=' . $this->view_list
+					. '&extension=' . $this->extension . ($this->section ? '.' . $this->section : ''), false
 				)
 			);
 

--- a/administrator/components/com_workflow/src/Controller/WorkflowsController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowsController.php
@@ -119,8 +119,8 @@ class WorkflowsController extends AdminController
 			$this->setMessage(Text::_('COM_WORKFLOW_DISABLE_DEFAULT'), 'warning');
 			$this->setRedirect(
 				Route::_(
-					'index.php?option=' . $this->option . '&view=' . $this->view_list
-					. '&extension=' . $this->extension, false
+				'index.php?option=' . $this->option . '&view=' . $this->view_list
+				. '&extension=' . $this->extension . ($this->section ? '.' . $this->section : ''), false
 				)
 			);
 


### PR DESCRIPTION
### Summary of Changes
Fix redirect after a warning


### Testing Instructions
On a fresh database go to workflows and try to remove the "default". 



### Expected result
Warnung and screen as before


### Actual result
Warning and screen is empty

