### PR TITLE
[CMS PR 31804] Integrate with changes from CMS PR 31943 for dry run and verbose mode

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7181,17 +7181,17 @@ class JoomlaInstallerScript
 
 		$files = array(
 			// 3.10 changes
-			'libraries/src/Filesystem/Support/Stringcontroller.php' => 'libraries/src/Filesystem/Support/StringController.php',
-			'libraries/src/Form/Rule/SubFormRule.php' => 'libraries/src/Form/Rule/SubformRule.php',
+			'/libraries/src/Filesystem/Support/Stringcontroller.php' => '/libraries/src/Filesystem/Support/StringController.php',
+			'/libraries/src/Form/Rule/SubFormRule.php' => '/libraries/src/Form/Rule/SubformRule.php',
 			// __DEPLOY_VERSION__
-			'media/vendor/skipto/js/skipTo.js' => 'media/vendor/skipto/js/skipto.js',
+			'/media/vendor/skipto/js/skipTo.js' => '/media/vendor/skipto/js/skipto.js',
 		);
 
 		foreach ($files as $old => $expected)
 		{
-			$status['checked'][] = '/' . $old;
+			$status['checked'][] = $old;
 
-			$oldRealpath = realpath(JPATH_ROOT . '/' . $old);
+			$oldRealpath = realpath(JPATH_ROOT . $old);
 
 			// On Unix without incorrectly cased file.
 			if ($oldRealpath === false)
@@ -7200,7 +7200,7 @@ class JoomlaInstallerScript
 			}
 
 			$oldBasename      = basename($oldRealpath);
-			$newRealpath      = realpath(JPATH_ROOT . '/' . $expected);
+			$newRealpath      = realpath(JPATH_ROOT . $expected);
 			$newBasename      = basename($newRealpath);
 			$expectedBasename = basename($expected);
 
@@ -7208,24 +7208,24 @@ class JoomlaInstallerScript
 			if ($newBasename !== $expectedBasename)
 			{
 				// Rename the file.
-				$status['exist'][] = '/' . $old;
+				$status['exist'][] = $old;
 
 				if ($dryRun === false)
 				{
-					if (!rename(JPATH_ROOT . '/' . $old, JPATH_ROOT . '/' . $old . '.tmp'))
+					if (!rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
 					{
-						$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', '/' . $old, '/' . $old . '.tmp');
+						$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', $old, $old . '.tmp');
 
 						continue;
 					}
 
-					if (rename(JPATH_ROOT . '/' . $old . '.tmp', JPATH_ROOT . '/' . $expected))
+					if (rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected))
 					{
-						$status['renamed'][] = '/' . $old;
+						$status['renamed'][] = $old;
 					}
 					else
 					{
-						$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', '/' . $old, '/' . $expected);
+						$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', $old, $expected);
 					}
 				}
 
@@ -7242,24 +7242,24 @@ class JoomlaInstallerScript
 					if (!in_array($expectedBasename, scandir(dirname($newRealpath))))
 					{
 						// Rename the file.
-						$status['exist'][] = '/' . $old;
+						$status['exist'][] = $old;
 
 						if ($dryRun === false)
 						{
-							if (!rename(JPATH_ROOT . '/' . $old, JPATH_ROOT . '/' . $old . '.tmp'))
+							if (!rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
 							{
-								$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', '/' . $old, '/' . $old . '.tmp');
+								$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', $old, $old . '.tmp');
 
 								continue;
 							}
 
-							if (rename(JPATH_ROOT . '/' . $old . '.tmp', JPATH_ROOT . '/' . $expected))
+							if (rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected))
 							{
-								$status['renamed'][] = '/' . $old;
+								$status['renamed'][] = $old;
 							}
 							else
 							{
-								$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', '/' . $old, '/' . $expected);
+								$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_RENAME', $old, $expected);
 							}
 						}
 					}
@@ -7267,17 +7267,17 @@ class JoomlaInstallerScript
 				else
 				{
 					// On Unix with both files: Delete the incorrectly cased file.
-					$status['exist'][] = '/' . $old;
+					$status['exist'][] = $old;
 
 					if ($dryRun === false)
 					{
-						if (unlink(JPATH_ROOT . '/' . $old))
+						if (unlink(JPATH_ROOT . $old))
 						{
-							$status['deleted'][] = '/' . $old;
+							$status['deleted'][] = $old;
 						}
 						else
 						{
-							$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', '/' . $old);
+							$status['errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $old);
 						}
 					}
 				}

--- a/language/en-GB/files_joomla.sys.ini
+++ b/language/en-GB/files_joomla.sys.ini
@@ -6,4 +6,5 @@
 FILES_JOOMLA="Joomla CMS"
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
+FILES_JOOMLA_ERROR_RENAME="Error on renaming file or folder from %s to %s"
 FILES_JOOMLA_XML_DESCRIPTION="Joomla! 4 Content Management System."


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/31804#issuecomment-766845867 .

### Summary of Changes

Adapt your CMS PR https://github.com/joomla/joomla-cms/pull/31804 to some ugly code in the 4.0-dev branch ;-)

It could have been done in other ways for the "fixFilenameCasing", e.g. passing the result array by reference from the calling function "deleteUnexistingFiles" , and/or leaving the verbose output to the calling function, but the way I've done it here will allow us to change the "fixFilenameCasing" function to public so it can be called independently from the "deleteUnexistingFiles" function.

The last commit also includes the same changes as I propose with [my new PR to the staging branch of the CMS](https://github.com/joomla/joomla-cms/pull/32176).

Feel free to change whatever you want or to reject it completely and say the CMS PR is good as it is.

### Testing Instructions

See if your PR still works and check with CLI if dry run and verbose mode work.