### PR TITLE
[CMS PR 43147] Use the right minimum stability

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -168,11 +168,9 @@ class UpdateModel extends BaseDatabaseModel
         }
 
         $updater               = Updater::getInstance();
-        $minimumStability      = Updater::STABILITY_STABLE;
         $comJoomlaupdateParams = ComponentHelper::getParams('com_joomlaupdate');
 
         $minimumStability = $comJoomlaupdateParams->get('minimum_stability', Updater::STABILITY_STABLE);
-
         $reflection       = new \ReflectionObject($updater);
         $reflectionMethod = $reflection->getMethod('findUpdates');
         $methodParameters = $reflectionMethod->getParameters();
@@ -289,13 +287,9 @@ class UpdateModel extends BaseDatabaseModel
             return $this->updateInformation;
         }
 
-        $minimumStability      = Updater::STABILITY_STABLE;
         $comJoomlaupdateParams = ComponentHelper::getParams('com_joomlaupdate');
         $channel               = $comJoomlaupdateParams->get('updatesource', 'default');
-
-        if (\in_array($channel, ['testing', 'custom'])) {
-            $minimumStability = $comJoomlaupdateParams->get('minimum_stability', Updater::STABILITY_STABLE);
-        }
+        $minimumStability      = $comJoomlaupdateParams->get('minimum_stability', Updater::STABILITY_STABLE);
 
         $update = new Update();
 

--- a/libraries/src/Updater/Adapter/TufAdapter.php
+++ b/libraries/src/Updater/Adapter/TufAdapter.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Table\Tuf as MetadataTable;
 use Joomla\CMS\TUF\TufFetcher;
 use Joomla\CMS\Updater\ConstraintChecker;
 use Joomla\CMS\Updater\UpdateAdapter;
+use Joomla\CMS\Updater\Updater;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tuf\Exception\MetadataException;
 
@@ -108,7 +109,7 @@ class TufAdapter extends UpdateAdapter
             // Return the version as a match if either all constraints are matched
             // or "only" env related constraints fail - the later one is the existing behavior of the XML updater
             if (
-                $constraintChecker->check($version) === true
+                $constraintChecker->check($version, $options['minimum_stability'] ?? Updater::STABILITY_STABLE) === true
                 || !empty((array) $constraintChecker->getFailedEnvironmentConstraints())
             ) {
                 return [$version];

--- a/libraries/src/Updater/ConstraintChecker.php
+++ b/libraries/src/Updater/ConstraintChecker.php
@@ -50,13 +50,14 @@ class ConstraintChecker
     /**
      * Checks whether the passed constraints are matched
      *
-     * @param array $candidate The provided constraints to be checked
+     * @param array $candidate         The provided constraints to be checked
+     * @param int   $minimumStability  The minimum stability required for updating
      *
      * @return  boolean
      *
      * @since   5.1.0
      */
-    public function check(array $candidate)
+    public function check(array $candidate, $minimumStability = Updater::STABILITY_STABLE)
     {
         if (!isset($candidate['targetplatform'])) {
             // targetplatform is required
@@ -89,7 +90,7 @@ class ConstraintChecker
         // Check stability, assume true when not set
         if (
             isset($candidate['stability'])
-            && !$this->checkStability($candidate['stability'])
+            && !$this->checkStability($candidate['stability'], $minimumStability)
         ) {
             $result = false;
         }
@@ -208,19 +209,18 @@ class ConstraintChecker
     /**
      * Check the stability
      *
-     * @param string $stability Stability to check
+     * @param string $stability         Stability to check
+     * @param int    $minimumStability  The minimum stability required for updating
      *
      * @return  boolean
      *
      * @since   5.1.0
      */
-    protected function checkStability(string $stability)
+    protected function checkStability(string $stability, $minimumStability = Updater::STABILITY_STABLE)
     {
-        $minimumStability = ComponentHelper::getParams('com_joomlaupdate')->get('minimum_stability', Updater::STABILITY_STABLE);
-
         $stabilityInt = $this->stabilityToInteger($stability);
 
-        if (($stabilityInt < $minimumStability)) {
+        if ($stabilityInt < $minimumStability) {
             return false;
         }
 

--- a/libraries/src/Updater/ConstraintChecker.php
+++ b/libraries/src/Updater/ConstraintChecker.php
@@ -13,7 +13,6 @@ namespace Joomla\CMS\Updater;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Version;

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -557,7 +557,7 @@ class Update
                 continue;
             }
 
-            if (!$constraintChecker->check($target['custom'])) {
+            if (!$constraintChecker->check($target['custom'], $minimumStability)) {
                 $this->otherUpdateInfo = $constraintChecker->getFailedEnvironmentConstraints();
 
                 continue;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/43147#discussion_r1537315838 .

### Summary of Changes

The minimum stability is passed as an option to the adapter and so can be used.

The existing parameter can be passed to the ConstraintChecker and the stability check.

This should fix the comment in the CMS PR mentioned above.

But I haven't tested it with your PR, I only have tested the same change when preparing my PR, which would have taken a bit longer.